### PR TITLE
Small bugfix.

### DIFF
--- a/src/geni/rspec.cc
+++ b/src/geni/rspec.cc
@@ -1559,7 +1559,9 @@ void GeniManifestRSpec::ParseApiReplyMessage(Message* msg)
                 {
                     aggregateUrn = GeniAdRSpec::aggregateUrnMap[domainId];
                 }
-                if (!aggregateUrn.empty() && aggregateUrn.compare(allAggregateUrns.back()) != 0) 
+                if (!aggregateUrn.empty() &&
+    		    (allAggregateUrns.empty() ||
+		     aggregateUrn.compare(allAggregateUrns.back()) != 0))
                 {
                     allAggregateUrns.push_back(aggregateUrn);
                 }


### PR DESCRIPTION
Make sure allAgregateUrns is not empty before trying to call .back() on it and send the result to compare.